### PR TITLE
feat: add lsp handler for `debug` codelens

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ require('dap-rego').setup(
     -- additional dap configurations
     configurations = {},
 
-    -- register `regal/startDebugging` handler to Neovim LSP
-    -- this enables to start debugger by `Debug` codelens
-    codelens_handler = true,
+    codelens_handler = {
+      -- register `regal/startDebugging` handler to Neovim LSP
+      -- this enables to start debugger by `Debug` codelens
+      start_debugging = true,
+    },
   }
 )
 ```

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ require('dap-rego').setup(
 
     -- additional dap configurations
     configurations = {},
+
+    -- register `regal/startDebugging` handler to Neovim LSP
+    -- this enables to start debugger by `Debug` codelens
+    codelens_handler = true,
   }
 )
 ```

--- a/doc/nvim-dap-rego.txt
+++ b/doc/nvim-dap-rego.txt
@@ -91,6 +91,10 @@ config table to this function.
 
         -- additional dap configurations
         configurations = {},
+
+        -- register `regal/startDebugging` handler to Neovim LSP
+        -- this enables to start debugger by `Debug` codelens
+        codelens_handler = true,
       }
     )
 <

--- a/doc/nvim-dap-rego.txt
+++ b/doc/nvim-dap-rego.txt
@@ -92,9 +92,11 @@ config table to this function.
         -- additional dap configurations
         configurations = {},
 
-        -- register `regal/startDebugging` handler to Neovim LSP
-        -- this enables to start debugger by `Debug` codelens
-        codelens_handler = true,
+        codelens_handler = {
+          -- register `regal/startDebugging` handler to Neovim LSP
+          -- this enables to start debugger by `Debug` codelens
+          start_debugging = true,
+        },
       }
     )
 <

--- a/fnl/dap-rego/init.fnl
+++ b/fnl/dap-rego/init.fnl
@@ -14,7 +14,8 @@
          :enable_print true
          :rule_indexing false}
         :configurations []
-        :codelens_handler true})
+        :codelens_handlers
+        {:start_debugging true}})
 
 (fn default-configurations [dap opts]
   (let [find-input-path (fn []
@@ -74,31 +75,34 @@
                          opts.configurations)]
     (set dap.configurations.rego configurations)))
 
-(fn setup-lsp-codelens-handler [dap opts]
-  (tset vim.lsp.handlers
-        :regal/startDebugging
-        (fn [err result ctx config]
-          (let [dconf (vim.tbl_deep_extend
-                       :force
-                       result
-                       {:stopOnEntry opts.defaults.stop_on_entry
-                        :stopOnFail opts.defaults.stop_on_fail
-                        :stopOnResult opts.defaults.stop_on_result
-                        :trace opts.defaults.trace
-                        :enablePrint opts.defaults.enable_print
-                        :ruleIndexing opts.defaults.rule_indexing
-                        :logLevel opts.defaults.log_level
-                        :bundlePaths ["${workspaceFolder}"]})]
-            (dap.run dconf))
-          (values {:code 0} nil))))
+(fn setup-lsp-codelens-handlers [dap opts]
+  (when opts.codelens_handlers.start_debugging
+    (tset vim.lsp.handlers
+          :regal/startDebugging
+          (fn [err result ctx config]
+            (if (not (= (dap.session) nil))
+              (values nil (vim.lsp.rpc.rpc_response_error
+                            vim.lsp.protocol.ErrorCodes.InvalidRequest
+                            "active debug session already exists"))
+              (let [dconf (vim.tbl_deep_extend
+                           :force
+                           result
+                           {:stopOnEntry opts.defaults.stop_on_entry
+                            :stopOnFail opts.defaults.stop_on_fail
+                            :stopOnResult opts.defaults.stop_on_result
+                            :trace opts.defaults.trace
+                            :enablePrint opts.defaults.enable_print
+                            :ruleIndexing opts.defaults.rule_indexing
+                            :logLevel opts.defaults.log_level
+                            :bundlePaths ["${workspaceFolder}"]})]
+                (dap.run dconf)
+                (values {:ok true} nil)))))))
 
 (fn setup [opts]
   (let [opts (vim.tbl_deep_extend :force default-opts (or opts {}))
         dap (utils.load-module :dap)]
     (setup-adapter dap opts)
     (setup-configurations dap opts)
-
-    (when opts.codelens_handler
-      (setup-lsp-codelens-handler dap opts))))
+    (setup-lsp-codelens-handlers dap opts)))
 
 {: setup}

--- a/lua/dap-rego/init.lua
+++ b/lua/dap-rego/init.lua
@@ -1,6 +1,6 @@
 -- [nfnl] Compiled from fnl/dap-rego/init.fnl by https://github.com/Olical/nfnl, do not edit.
 local utils = require("dap-rego.utils")
-local default_opts = {adapter_name = "regal-debug", regal = {path = "regal", args = {"debug"}}, defaults = {log_level = "info", stop_on_entry = true, stop_on_result = true, trace = true, enable_print = true, rule_indexing = false, stop_on_fail = false}, configurations = {}, codelens_handler = true}
+local default_opts = {adapter_name = "regal-debug", regal = {path = "regal", args = {"debug"}}, defaults = {log_level = "info", stop_on_entry = true, stop_on_result = true, trace = true, enable_print = true, rule_indexing = false, stop_on_fail = false}, configurations = {}, codelens_handlers = {start_debugging = true}}
 local function default_configurations(dap, opts)
   local find_input_path
   local function _1_()
@@ -38,26 +38,28 @@ local function setup_configurations(dap, opts)
   dap.configurations.rego = configurations
   return nil
 end
-local function setup_lsp_codelens_handler(dap, opts)
-  local function _7_(err, result, ctx, config)
-    do
-      local dconf = vim.tbl_deep_extend("force", result, {stopOnEntry = opts.defaults.stop_on_entry, stopOnFail = opts.defaults.stop_on_fail, stopOnResult = opts.defaults.stop_on_result, trace = opts.defaults.trace, enablePrint = opts.defaults.enable_print, ruleIndexing = opts.defaults.rule_indexing, logLevel = opts.defaults.log_level, bundlePaths = {"${workspaceFolder}"}})
-      dap.run(dconf)
+local function setup_lsp_codelens_handlers(dap, opts)
+  if opts.codelens_handlers.start_debugging then
+    local function _7_(err, result, ctx, config)
+      if not (dap.session() == nil) then
+        return nil, vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest, "active debug session already exists")
+      else
+        local dconf = vim.tbl_deep_extend("force", result, {stopOnEntry = opts.defaults.stop_on_entry, stopOnFail = opts.defaults.stop_on_fail, stopOnResult = opts.defaults.stop_on_result, trace = opts.defaults.trace, enablePrint = opts.defaults.enable_print, ruleIndexing = opts.defaults.rule_indexing, logLevel = opts.defaults.log_level, bundlePaths = {"${workspaceFolder}"}})
+        dap.run(dconf)
+        return {ok = true}, nil
+      end
     end
-    return {code = 0}, nil
+    vim.lsp.handlers["regal/startDebugging"] = _7_
+    return nil
+  else
+    return nil
   end
-  vim.lsp.handlers["regal/startDebugging"] = _7_
-  return nil
 end
 local function setup(opts)
   local opts0 = vim.tbl_deep_extend("force", default_opts, (opts or {}))
   local dap = utils["load-module"]("dap")
   setup_adapter(dap, opts0)
   setup_configurations(dap, opts0)
-  if opts0.codelens_handler then
-    return setup_lsp_codelens_handler(dap, opts0)
-  else
-    return nil
-  end
+  return setup_lsp_codelens_handlers(dap, opts0)
 end
 return {setup = setup}

--- a/lua/dap-rego/init.lua
+++ b/lua/dap-rego/init.lua
@@ -1,6 +1,6 @@
 -- [nfnl] Compiled from fnl/dap-rego/init.fnl by https://github.com/Olical/nfnl, do not edit.
 local utils = require("dap-rego.utils")
-local default_opts = {adapter_name = "regal-debug", regal = {path = "regal", args = {"debug"}}, defaults = {log_level = "info", stop_on_entry = true, stop_on_result = true, trace = true, enable_print = true, rule_indexing = false, stop_on_fail = false}, configurations = {}}
+local default_opts = {adapter_name = "regal-debug", regal = {path = "regal", args = {"debug"}}, defaults = {log_level = "info", stop_on_entry = true, stop_on_result = true, trace = true, enable_print = true, rule_indexing = false, stop_on_fail = false}, configurations = {}, codelens_handler = true}
 local function default_configurations(dap, opts)
   local find_input_path
   local function _1_()
@@ -38,10 +38,26 @@ local function setup_configurations(dap, opts)
   dap.configurations.rego = configurations
   return nil
 end
+local function setup_lsp_codelens_handler(dap, opts)
+  local function _7_(err, result, ctx, config)
+    do
+      local dconf = vim.tbl_deep_extend("force", result, {stopOnEntry = opts.defaults.stop_on_entry, stopOnFail = opts.defaults.stop_on_fail, stopOnResult = opts.defaults.stop_on_result, trace = opts.defaults.trace, enablePrint = opts.defaults.enable_print, ruleIndexing = opts.defaults.rule_indexing, logLevel = opts.defaults.log_level, bundlePaths = {"${workspaceFolder}"}})
+      dap.run(dconf)
+    end
+    return {code = 0}, nil
+  end
+  vim.lsp.handlers["regal/startDebugging"] = _7_
+  return nil
+end
 local function setup(opts)
   local opts0 = vim.tbl_deep_extend("force", default_opts, (opts or {}))
   local dap = utils["load-module"]("dap")
   setup_adapter(dap, opts0)
-  return setup_configurations(dap, opts0)
+  setup_configurations(dap, opts0)
+  if opts0.codelens_handler then
+    return setup_lsp_codelens_handler(dap, opts0)
+  else
+    return nil
+  end
 end
 return {setup = setup}


### PR DESCRIPTION
To use Regal's `Debug` codelens added by https://github.com/StyraInc/regal/pull/1103 in Neovim, this pull request adds a feature to register LSP handler for `regal/startDebugging` method.